### PR TITLE
Fix error in documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,8 +12,8 @@ This will provide you with a "consumer key", "consumer secret", and "application
 
 === To use authenticated features (i.e. queue management):
 * Set the consumer/developer config:
-    Netflix.consumer_key = <your consumer/developer key>
-    Netflix.consumer_secret = <your consumer/developer secret>
+    Netflix::Client.consumer_key = <your consumer/developer key>
+    Netflix::Client.consumer_secret = <your consumer/developer secret>
 
 * Do OAuth dance: (This is a one-time per user step, save the result somewhere.)
   1. Interactive (commandline/irb):


### PR DESCRIPTION
Hi,

I fixed an error in the documentation, specifically in the initialization example. It was incomplete, and the only way to find the proper code was to dig into the tests.

It's not much, but I hope it can make it easier for people to use your gem.

Cheers,
