### PR TITLE
Extract a .gemspec

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib/', __FILE__)
+$:.unshift lib unless $:.include?(lib)
+ 
+require 'netflix/version'
+
+Gem::Specification.new do |s|
+  s.name = "netflix"
+  s.version = Netflix::VERSION
+  s.authors = ["Dean Holdren"]
+  s.date = %q{2012-01-09}
+  s.description = "Ruby Netflix API wrapper"
+  s.summary = s.description
+  s.email = 'deanholdren@gmail.com'
+  
+  s.require_path = "lib"
+  s.files = `git ls-files`.split("\n")
+  s.test_files = `git ls-files -- test/*`.split("\n")
+  
+  s.homepage = "https://github.com/dholdren/netflix-ruby"
+  s.has_rdoc = false
+  
+  s.add_dependency("oauth")
+  s.add_dependency("json")
+  s.add_dependency("launchy")
+  s.add_development_dependency("fakeweb")
+end
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source :rubygems
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,24 @@
+PATH
+  remote: .
+  specs:
+    netflix (0.2.1)
+      json
+      launchy
+      oauth
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.2.8)
+    fakeweb (1.3.0)
+    json (1.7.0)
+    launchy (2.1.0)
+      addressable (~> 2.2.6)
+    oauth (0.4.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fakeweb
+  netflix!

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
+# -*- encoding: utf-8 -*-
 require 'rake/testtask'
-require 'rubygems/package_task'
+lib = File.expand_path('../lib/', __FILE__)
+$:.unshift lib unless $:.include?(lib)
 
 Rake::TestTask.new("test:unit") { |t|
   t.libs << 'test'
@@ -31,29 +33,14 @@ task "test:integration" => "test/integration/oauth_settings.yml"
 desc "run unit tests only"
 task :test => "test:unit"
 
-gem_spec = Gem::Specification.new do |s|
-  s.name = "netflix"
-  s.version = "0.2.1"
-  s.authors = ["Dean Holdren"]
-  s.date = %q{2012-01-09}
-  s.description = "Ruby Netflix API wrapper"
-  s.summary = s.description
-  s.email = 'deanholdren@gmail.com'
-  
-  s.require_path = "lib"
-  s.files = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- test/*`.split("\n")
-  
-  s.homepage = "https://github.com/dholdren/netflix-ruby"
-  s.has_rdoc = false
-  
-  s.add_dependency("oauth")
-  s.add_dependency("json")
-  s.add_dependency("launchy")
-  s.add_development_dependency("fakeweb")
-  s.add_development_dependency("yaml")
+# Gem tasks
+require "netflix/version"
+ 
+task :build do
+  system "gem build .gemspec"
+end
+ 
+task :release => :build do
+  system "gem push bundler-#{Netflix::VERSION}"
 end
 
-Gem::PackageTask.new(gem_spec) do |pkg|
-  pkg.need_zip = true
-end

--- a/lib/netflix/version.rb
+++ b/lib/netflix/version.rb
@@ -1,0 +1,3 @@
+module Netflix
+  VERSION = '0.2.1'
+end


### PR DESCRIPTION
In order to make some changes to the library, I need to be able to
require it from bundler from the non-rubygems source.

For that to work there needs to be a gemspec in the repo itself.

I followed the guidelines in http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/ to set everything up.
